### PR TITLE
POST /api/estate がファイルの列数によるクエリ発行されること解消 

### DIFF
--- a/webapp/ruby/api-mondai.md
+++ b/webapp/ruby/api-mondai.md
@@ -24,5 +24,48 @@ coordinates_to_text = "'POLYGON((%s))'" % coordinates.map { |c| '%f %f' % c.valu
 sql = 'SELECT *, ST_Contains(ST_PolygonFromText(%s), ST_GeomFromText(POINT(latitude longitude))) FROM estate WHERE id IN ? LIMIT ?' % [coordinates_to_text]
 
 estates_in_polygon = db.xquery(sql, estate_ids, NAZOTTE_LIMIT)
-
+nazotte_estates = estates_in_polygon.select { |e| e.is_geom_contain }
 ```
+
+
+## POST /api/estate
+- Send file to Server and read file
+- 列ごとにInsert Queryが発行される
+- すごく大きいファイルの場合はInsertのクエリは何回も発行される
+```ruby
+post '/api/estate' do
+  unless params[:estates]
+    logger.error 'Failed to get form file'
+    halt 400
+  end
+
+  transaction('post_api_estate') do
+    CSV.parse(params[:estates][:tempfile].read, skip_blanks: true) do |row|
+      sql = 'INSERT INTO estate(id, name, description, thumbnail, address, latitude, longitude, rent, door_height, door_width, features, popularity) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+      db.xquery(sql, *row.map(&:to_s))
+    end
+  end
+
+  status 201
+end
+```
+- fix: Valuesを生成したあと、Insertクエリが発行されるように修正
+```ruby
+post '/api/estate' do
+  unless params[:estates]
+    logger.error 'Failed to get form file'
+    halt 400
+  end
+
+  arr_values = []
+  CSV.parse(params[:estates][:tempfile].read, skip_blanks: true) do |row|
+    v = "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)" % *row.map(&:to_s)
+    arr_values << v
+  end
+  values = arr_values.join(',')
+
+  sql = 'INSERT INTO estate(id, name, description, thumbnail, address, latitude, longitude, rent, door_height, door_width, features, popularity) VALUES ?'
+  db.xquery(sql, values)
+
+  status 201
+end

--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -509,14 +509,17 @@ class App < Sinatra::Base
       logger.error 'Failed to get form file'
       halt 400
     end
-
-    transaction('post_api_estate') do
-      CSV.parse(params[:estates][:tempfile].read, skip_blanks: true) do |row|
-        sql = 'INSERT INTO estate(id, name, description, thumbnail, address, latitude, longitude, rent, door_height, door_width, features, popularity) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-        db.xquery(sql, *row.map(&:to_s))
-      end
+  
+    arr_values = []
+    CSV.parse(params[:estates][:tempfile].read, skip_blanks: true) do |row|
+      v = "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)" % *row.map(&:to_s)
+      arr_values << v
     end
-
+    values = arr_values.join(',')
+  
+    sql = 'INSERT INTO estate(id, name, description, thumbnail, address, latitude, longitude, rent, door_height, door_width, features, popularity) VALUES ?'
+    db.xquery(sql, values)
+  
     status 201
   end
 


### PR DESCRIPTION
https://github.com/minhquang4334/Isucon10-q/blob/3f9d7f77130edea09b046d8c380cac3ab1a28ffb/webapp/ruby/api-mondai.md#L54-L71